### PR TITLE
feat: HU18 data formatter

### DIFF
--- a/backend/api/tests/test_prepare_data.py
+++ b/backend/api/tests/test_prepare_data.py
@@ -1,0 +1,169 @@
+from api.utils.common.prepare_data import (
+    prepare_commits,
+    prepare_issues,
+    prepare_pulls,
+    prepare_contributors,
+)
+
+
+def test_prepare_commits_basic():
+    data = [
+        {
+            "hash": "abc123",
+            "parent_hashes": ["def456"],
+            "author": "alice",
+            "date": "2024-01-01T12:00:00",
+            "message": "Initial commit" * 30,
+            "files_changed": ["file1.py"],
+            "n_files_changed": 1,
+            "insertions": 10,
+            "deletions": 0,
+            "commit_type": "normal",
+            "bot_field": "not_a_bot",
+        },
+        {
+            "hash": "def456",
+            "parent_hashes": [],
+            "author": "dependabot[bot]",
+            "date": "2024-01-02T12:00:00",
+            "message": "Bump deps",
+            "files_changed": ["file2.py"],
+            "n_files_changed": 1,
+            "insertions": 5,
+            "deletions": 1,
+            "commit_type": "bot",
+        },
+    ]
+    cleaned = prepare_commits(data)
+    assert len(cleaned) == 1
+    assert cleaned[0]["author"] == "alice"
+    assert len(cleaned[0]["message"]) <= 203
+    assert set(cleaned[0].keys()) == {
+        "hash",
+        "parent_hashes",
+        "author",
+        "date",
+        "message",
+        "files_changed",
+        "n_files_changed",
+        "insertions",
+        "deletions",
+    }
+
+
+def test_prepare_issues_basic():
+    data = [
+        {
+            "number": 1,
+            "title": "Bug found" * 50,
+            "author": {"login": "bob"},
+            "state": "open",
+            "createdAt": "2024-01-01T10:00:00",
+            "closedAt": None,
+            "body": "A" * 300,
+            "comments": {"totalCount": 2},
+            "labels": {"nodes": ["bug"]},
+        },
+        {
+            "number": 2,
+            "title": "Automated issue",
+            "author": {"login": "bot[bot]"},
+            "state": "closed",
+            "createdAt": "2024-01-02T10:00:00",
+            "closedAt": "2024-01-03T10:00:00",
+            "body": "Automated",
+            "comments": {"totalCount": 0},
+            "labels": {"nodes": []},
+        },
+    ]
+    # Simula el flatten del campo author y la extracción de comentarios/labels como haría el pipeline real
+    for issue in data:
+        issue["author"] = issue["author"]["login"]
+        issue["comments"] = issue["comments"]["totalCount"]
+        issue["labels"] = issue["labels"]["nodes"]
+    cleaned = prepare_issues(data)
+    assert len(cleaned) == 1
+    assert cleaned[0]["author"] == "bob"
+    assert len(cleaned[0]["title"]) <= 203
+    assert len(cleaned[0]["body"]) <= 203
+    assert set(cleaned[0].keys()) == {
+        "number",
+        "author",
+        "title",
+        "state",
+        "createdAt",
+        "closedAt",
+        "body",
+        "comments",
+        "labels",
+    }
+
+
+def test_prepare_pulls_basic():
+    data = [
+        {
+            "number": 1,
+            "title": "Add feature" * 30,
+            "author": {"login": "carol"},
+            "mergedBy": {"login": "dave"},
+            "state": "merged",
+            "createdAt": "2024-01-01T09:00:00",
+            "closedAt": "2024-01-02T09:00:00",
+            "mergedAt": "2024-01-02T09:00:00",
+            "body": "B" * 600,
+            "comments": {"totalCount": 5},
+            "labels": {"nodes": ["enhancement"]},
+        },
+        {
+            "number": 2,
+            "title": "Update deps",
+            "author": {"login": "dependabot[bot]"},
+            "mergedBy": {"login": "dave"},
+            "state": "closed",
+            "createdAt": "2024-01-03T09:00:00",
+            "closedAt": "2024-01-04T09:00:00",
+            "mergedAt": None,
+            "body": "Auto",
+            "comments": {"totalCount": 0},
+            "labels": {"nodes": []},
+        },
+    ]
+    for pull in data:
+        pull["author"] = pull["author"]["login"]
+        pull["mergedBy"] = pull["mergedBy"]["login"]
+        pull["comments"] = pull["comments"]["totalCount"]
+        pull["labels"] = pull["labels"]["nodes"]
+    cleaned = prepare_pulls(data)
+    assert len(cleaned) == 1
+    assert cleaned[0]["author"] == "carol"
+    assert len(cleaned[0]["title"]) <= 203
+    assert len(cleaned[0]["body"]) <= 503
+    assert set(cleaned[0].keys()) == {
+        "number",
+        "title",
+        "author",
+        "mergedBy",
+        "state",
+        "createdAt",
+        "closedAt",
+        "mergedAt",
+        "body",
+        "comments",
+        "labels",
+    }
+
+
+def test_prepare_contributors_basic():
+    data = [
+        {"login": "eve", "createdAt": "2024-01-01T08:00:00", "bio": "C" * 300},
+        {
+            "login": "github-actions[bot]",
+            "createdAt": "2024-01-02T08:00:00",
+            "bio": "Automated",
+        },
+    ]
+    cleaned = prepare_contributors(data)
+    assert len(cleaned) == 1
+    assert cleaned[0]["login"] == "eve"
+    assert len(cleaned[0]["bio"]) <= 203
+    assert "createdAt" in cleaned[0]

--- a/backend/api/tests/test_prepare_data.py
+++ b/backend/api/tests/test_prepare_data.py
@@ -76,7 +76,6 @@ def test_prepare_issues_basic():
             "labels": {"nodes": []},
         },
     ]
-    # Simula el flatten del campo author y la extracción de comentarios/labels como haría el pipeline real
     for issue in data:
         issue["author"] = issue["author"]["login"]
         issue["comments"] = issue["comments"]["totalCount"]

--- a/backend/api/utils/common/prepare_data.py
+++ b/backend/api/utils/common/prepare_data.py
@@ -83,14 +83,13 @@ def prepare_issues(
     issues: List[Dict[str, Any]], max_items: int = 100
 ) -> List[Dict[str, Any]]:
     issues = issues[:max_items]
-    issues = filter_bots(issues, user_field="user")
+    issues = filter_bots(issues, user_field="author")
     issues = normalize_dates(issues, ["createdAt", "closedAt"])
     issues = truncate_texts(issues, ["title", "body"], max_length=200)
     fields = [
         "number",
         "author",
         "title",
-        "user",
         "state",
         "createdAt",
         "closedAt",
@@ -106,7 +105,7 @@ def prepare_pulls(
     pulls: List[Dict[str, Any]], max_items: int = 100
 ) -> List[Dict[str, Any]]:
     pulls = pulls[:max_items]
-    pulls = filter_bots(pulls, user_field="user")
+    pulls = filter_bots(pulls, user_field="author")
     pulls = normalize_dates(pulls, ["createdAt", "closedAt", "mergedAt"])
     pulls = truncate_texts(pulls, ["title"], max_length=200)
     pulls = truncate_texts(pulls, ["body"], max_length=500)

--- a/backend/api/utils/common/prepare_data.py
+++ b/backend/api/utils/common/prepare_data.py
@@ -1,0 +1,138 @@
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+import re
+
+
+def filter_bots(
+    data: List[Dict[str, Any]], user_field: str = "author"
+) -> List[Dict[str, Any]]:
+    """Remove items where the user is a bot (by username or email)."""
+    return [
+        item
+        for item in data
+        if not re.search(r"bot", str(item.get(user_field, "")).lower())
+    ]
+
+
+def normalize_dates(
+    data: List[Dict[str, Any]],
+    date_fields: Optional[List[str]] = None,
+    fmt: str = "%Y-%m-%d",
+) -> List[Dict[str, Any]]:
+    """Convert all date fields to a consistent string format."""
+    if date_fields is None:
+        date_fields = [
+            k for k in data[0].keys() if "date" in k or "created" in k or "updated" in k
+        ]
+    for item in data:
+        for field in date_fields:
+            if field in item and item[field]:
+                try:
+                    item[field] = datetime.fromisoformat(str(item[field])).strftime(fmt)
+                except Exception:
+                    item[field] = str(item[field])[:10]
+    return data
+
+
+def truncate_texts(
+    data: List[Dict[str, Any]], fields: List[str], max_length: int = 200
+) -> List[Dict[str, Any]]:
+    """Truncate long text fields to max_length."""
+    for item in data:
+        for field in fields:
+            if (
+                field in item
+                and isinstance(item[field], str)
+                and len(item[field]) > max_length
+            ):
+                item[field] = item[field][:max_length] + "..."
+    return data
+
+
+def select_fields(
+    data: List[Dict[str, Any]], fields: List[str]
+) -> List[Dict[str, Any]]:
+    """Keep only the specified fields in each item."""
+    return [{k: v for k, v in item.items() if k in fields} for item in data]
+
+
+def prepare_commits(
+    commits: List[Dict[str, Any]], max_items: int = 100
+) -> List[Dict[str, Any]]:
+    """Pipeline to clean and prepare commit data for prompts."""
+    commits = commits[:max_items]
+    commits = filter_bots(commits, user_field="author")
+    commits = normalize_dates(commits, ["date", "committer_date"])
+    commits = truncate_texts(commits, ["message"], max_length=200)
+    fields = [
+        "hash",
+        "parent_hashes",
+        "author",
+        "date",
+        "message",
+        "files_changed",
+        "n_files_changed",
+        "insertions",
+        "deletions",
+    ]
+    commits = select_fields(commits, fields)
+    return commits
+
+
+def prepare_issues(
+    issues: List[Dict[str, Any]], max_items: int = 100
+) -> List[Dict[str, Any]]:
+    issues = issues[:max_items]
+    issues = filter_bots(issues, user_field="user")
+    issues = normalize_dates(issues, ["createdAt", "closedAt"])
+    issues = truncate_texts(issues, ["title", "body"], max_length=200)
+    fields = [
+        "number",
+        "author",
+        "title",
+        "user",
+        "state",
+        "createdAt",
+        "closedAt",
+        "body",
+        "comments",
+        "labels",
+    ]
+    issues = select_fields(issues, fields)
+    return issues
+
+
+def prepare_pulls(
+    pulls: List[Dict[str, Any]], max_items: int = 100
+) -> List[Dict[str, Any]]:
+    pulls = pulls[:max_items]
+    pulls = filter_bots(pulls, user_field="user")
+    pulls = normalize_dates(pulls, ["createdAt", "closedAt", "mergedAt"])
+    pulls = truncate_texts(pulls, ["title"], max_length=200)
+    pulls = truncate_texts(pulls, ["body"], max_length=500)
+    fields = [
+        "number",
+        "title",
+        "author",
+        "mergedBy",
+        "state",
+        "createdAt",
+        "closedAt",
+        "mergedAt",
+        "body",
+        "comments",
+        "labels",
+    ]
+    pulls = select_fields(pulls, fields)
+    return pulls
+
+
+def prepare_contributors(
+    contributors: List[Dict[str, Any]], max_items: int = 100
+) -> List[Dict[str, Any]]:
+    """Pipeline to clean and prepare contributor data for prompts."""
+    contributors = contributors[:max_items]
+    contributors = filter_bots(contributors, user_field="login")
+    contributors = normalize_dates(contributors, ["createdAt"])
+    contributors = truncate_texts(contributors, ["bio"], max_length=200)
+    return contributors


### PR DESCRIPTION
This pull request introduces a set of utility functions to clean and prepare data for commits, issues, pull requests, and contributors, along with corresponding unit tests to validate their functionality. The changes aim to streamline data processing by filtering out bots, normalizing date formats, truncating text fields, and selecting relevant fields.

### Additions to data preparation utilities:

* **Bot filtering**: Added the `filter_bots` function to exclude items authored by bots based on their username or email.
* **Date normalization**: Introduced the `normalize_dates` function to standardize date fields to a consistent format.
* **Text truncation**: Implemented the `truncate_texts` function to limit the length of text fields, ensuring concise data.
* **Field selection**: Added the `select_fields` function to retain only specified fields in the data.

### Pipelines for specific data types:

* **Commits**: Created the `prepare_commits` pipeline to clean commit data by applying bot filtering, date normalization, text truncation, and field selection.
* **Issues**: Developed the `prepare_issues` pipeline to process issue data with similar cleaning steps, tailored to issue-specific fields.
* **Pull requests**: Added the `prepare_pulls` pipeline, including additional truncation for pull request bodies.
* **Contributors**: Implemented the `prepare_contributors` pipeline to clean contributor data, focusing on bot filtering and bio truncation.

### Unit tests for data preparation:

* **Test coverage**: Added tests in `test_prepare_data.py` to validate the behavior of each preparation pipeline (`prepare_commits`, `prepare_issues`, `prepare_pulls`, and `prepare_contributors`). These tests ensure that bot filtering, text truncation, field selection, and other transformations work as intended.