### PR TITLE
feat: HU04 Top Contributors

### DIFF
--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo } from "react";
+import { useState, useMemo } from "react";
+import GivizButton from "../components/GivizButton";
 
 function getAllRoles(contributorsData) {
   const rolesSet = new Set();
@@ -35,6 +36,7 @@ export default function TopContributorsByRole({ contributors }) {
   const [hovered, setHovered] = useState({ username: null, roleKey: null });
   const allRoles = useMemo(() => getAllRoles(contributors), [contributors]);
   const [selectedRoles, setSelectedRoles] = useState(() => allRoles);
+  const [showChecklist, setShowChecklist] = useState(false);
 
   const handleRoleToggle = (roleKey) => {
     setSelectedRoles((prev) =>
@@ -46,24 +48,33 @@ export default function TopContributorsByRole({ contributors }) {
 
   return (
     <div className="w-full flex flex-col items-center py-6">
-      <div className="mb-6 w-full max-w-lg flex flex-wrap gap-3 justify-center">
-        {allRoles.map((roleKey) => (
-          <label
-            key={roleKey}
-            className="flex items-center gap-2 bg-gray-100 rounded px-2 py-1 cursor-pointer"
-          >
-            <input
-              type="checkbox"
-              checked={selectedRoles.includes(roleKey)}
-              onChange={() => handleRoleToggle(roleKey)}
-              className="accent-givizBlue4"
-            />
-            <span className="text-sm font-medium text-gray-700">
-              {getRoleLabel(roleKey)}
-            </span>
-          </label>
-        ))}
-      </div>
+      <GivizButton
+        className="mb-4"
+        onClick={() => setShowChecklist((v) => !v)}
+        aria-expanded={showChecklist}
+      >
+        {showChecklist ? "Hide filters" : "Show filters"}
+      </GivizButton>
+      {showChecklist && (
+        <div className="mb-6 w-full max-w-lg flex flex-wrap gap-3 justify-center">
+          {allRoles.map((roleKey) => (
+            <label
+              key={roleKey}
+              className="flex items-center gap-2 bg-gray-100 rounded px-2 py-1 cursor-pointer"
+            >
+              <input
+                type="checkbox"
+                checked={selectedRoles.includes(roleKey)}
+                onChange={() => handleRoleToggle(roleKey)}
+                className="accent-givizBlue4"
+              />
+              <span className="text-sm font-medium text-gray-700">
+                {getRoleLabel(roleKey)}
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
       <div className="w-full rounded-2xl p-7 flex flex-col gap-4">
         <div className="flex flex-row items-center gap-4 w-full mb-2">
           <div className="min-w-[100px]" />

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+
+const ROLE_LABELS = {
+  development: "Developer",
+  testing: "Tester",
+  documentation: "Docs",
+};
+
+function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
+  const result = [];
+  for (const [username, roles] of Object.entries(contributorsData || {})) {
+    if (roles[roleKey]) {
+      const { commits = 0, issues = 0, pulls = 0 } = roles[roleKey];
+      const total = commits + issues + pulls;
+      result.push({ username, total });
+    }
+  }
+  return result.sort((a, b) => b.total - a.total).slice(0, topN);
+}
+
+export default function TopContributorsByRole({ contributors }) {
+  return (
+    <div className="w-full">
+      <h2 className="text-xl font-semibold text-center mb-4">
+        Top 3 Contributors by Role
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {Object.entries(ROLE_LABELS).map(([roleKey, label]) => {
+          const top = getTopContributorsByRole(contributors, roleKey, 3);
+          return (
+            <div
+              key={roleKey}
+              className="bg-white rounded-xl shadow p-4 border border-gray-200"
+            >
+              <h3 className="text-lg font-bold mb-2 text-givizBlue4 text-center">
+                {label}
+              </h3>
+              {top.length === 0 ? (
+                <div className="text-gray-400 text-center">No contributors</div>
+              ) : (
+                <ol className="list-decimal pl-4">
+                  {top.map((user) => (
+                    <li
+                      key={user.username}
+                      className="mb-1 flex justify-between"
+                    >
+                      <span className="font-medium">{user.username}</span>
+                      <span className="text-gray-500">{user.total} pts</span>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -1,11 +1,23 @@
-import React from "react";
-import { useState } from "react";
+import React, { useState, useMemo } from "react";
 
-const ROLE_LABELS = {
-  development: "Developer",
-  testing: "Tester",
-  documentation: "Docs",
-};
+function getAllRoles(contributorsData) {
+  const rolesSet = new Set();
+  Object.values(contributorsData || {}).forEach((roles) => {
+    Object.keys(roles).forEach((role) => rolesSet.add(role));
+  });
+  return Array.from(rolesSet);
+}
+
+function getRoleLabel(roleKey) {
+  const defaultLabels = {
+    development: "Developer",
+    testing: "Tester",
+    documentation: "Docs",
+  };
+  return (
+    defaultLabels[roleKey] || roleKey.charAt(0).toUpperCase() + roleKey.slice(1)
+  );
+}
 
 function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
   const result = [];
@@ -21,46 +33,15 @@ function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
 
 export default function TopContributorsByRole({ contributors }) {
   const [hovered, setHovered] = useState({ username: null, roleKey: null });
-  const ROLE_ICONS = {
-    development: (
-      <span className="inline-block mr-2 text-givizBlue4">
-        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
-          <path
-            d="M8 17l-5-5 5-5M16 7l5 5-5 5"
-            stroke="#2563eb"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </span>
-    ),
-    testing: (
-      <span className="inline-block mr-2 text-green-500">
-        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
-          <path
-            d="M9 12l2 2 4-4"
-            stroke="#22c55e"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </span>
-    ),
-    documentation: (
-      <span className="inline-block mr-2 text-yellow-500">
-        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
-          <path
-            d="M7 7h10M7 11h10M7 15h6"
-            stroke="#eab308"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </span>
-    ),
+  const allRoles = useMemo(() => getAllRoles(contributors), [contributors]);
+  const [selectedRoles, setSelectedRoles] = useState(() => allRoles);
+
+  const handleRoleToggle = (roleKey) => {
+    setSelectedRoles((prev) =>
+      prev.includes(roleKey)
+        ? prev.filter((r) => r !== roleKey)
+        : [...prev, roleKey]
+    );
   };
 
   return (
@@ -68,6 +49,24 @@ export default function TopContributorsByRole({ contributors }) {
       <h2 className="text-2xl font-extrabold text-center mb-8 text-givizBlue4 tracking-wide">
         Top 3 Contributors by Role
       </h2>
+      <div className="mb-6 w-full max-w-lg flex flex-wrap gap-3 justify-center">
+        {allRoles.map((roleKey) => (
+          <label
+            key={roleKey}
+            className="flex items-center gap-2 bg-gray-100 rounded px-2 py-1 cursor-pointer"
+          >
+            <input
+              type="checkbox"
+              checked={selectedRoles.includes(roleKey)}
+              onChange={() => handleRoleToggle(roleKey)}
+              className="accent-givizBlue4"
+            />
+            <span className="text-sm font-medium text-gray-700">
+              {getRoleLabel(roleKey)}
+            </span>
+          </label>
+        ))}
+      </div>
       <div className="w-full rounded-2xl p-7 flex flex-col gap-4">
         <div className="flex flex-row items-center gap-6 w-full mb-2">
           <div className="min-w-[120px]" />
@@ -83,7 +82,8 @@ export default function TopContributorsByRole({ contributors }) {
             </div>
           </div>
         </div>
-        {Object.entries(ROLE_LABELS).map(([roleKey, label]) => {
+        {/* Mostrar solo los roles seleccionados */}
+        {selectedRoles.map((roleKey) => {
           const top = getTopContributorsByRole(contributors, roleKey, 3) || [];
           return (
             <div
@@ -91,9 +91,8 @@ export default function TopContributorsByRole({ contributors }) {
               className="flex flex-row items-center gap-6 w-full"
             >
               <div className="flex items-center min-w-[120px]">
-                {ROLE_ICONS[roleKey]}
                 <span className="text-lg font-bold text-givizBlue4 uppercase tracking-wide drop-shadow">
-                  {label}
+                  {getRoleLabel(roleKey)}
                 </span>
               </div>
               <div className="flex flex-row gap-4 w-full justify-center">

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -65,21 +65,20 @@ export default function TopContributorsByRole({ contributors }) {
         ))}
       </div>
       <div className="w-full rounded-2xl p-7 flex flex-col gap-4">
-        <div className="flex flex-row items-center gap-6 w-full mb-2">
-          <div className="min-w-[120px]" />
-          <div className="flex flex-row gap-4 w-full justify-center">
-            <div className="flex flex-col items-center min-w-[100px]">
-              <span className="text-3xl">🥇</span>
+        <div className="flex flex-row items-center gap-4 w-full mb-2">
+          <div className="min-w-[100px]" />
+          <div className="flex flex-row gap-2 w-full justify-center">
+            <div className="flex flex-col items-center min-w-[120px] max-w-[160px]">
+              <span className="text-2xl">🥇</span>
             </div>
-            <div className="flex flex-col items-center min-w-[100px]">
-              <span className="text-3xl">🥈</span>
+            <div className="flex flex-col items-center min-w-[120px] max-w-[160px]">
+              <span className="text-2xl">🥈</span>
             </div>
-            <div className="flex flex-col items-center min-w-[100px]">
-              <span className="text-3xl">🥉</span>
+            <div className="flex flex-col items-center min-w-[120px] max-w-[160px]">
+              <span className="text-2xl">🥉</span>
             </div>
           </div>
         </div>
-        {/* Mostrar solo los roles seleccionados */}
         {selectedRoles.map((roleKey) => {
           const top = getTopContributorsByRole(contributors, roleKey, 3) || [];
           return (
@@ -88,11 +87,11 @@ export default function TopContributorsByRole({ contributors }) {
               className="flex flex-row items-center gap-6 w-full"
             >
               <div className="flex items-center min-w-[120px]">
-                <span className="text-lg font-bold text-givizBlue4 uppercase tracking-wide drop-shadow">
+                <span className="text-base font-semibold text-givizBlue4 uppercase tracking-wide drop-shadow">
                   {getRoleLabel(roleKey)}
                 </span>
               </div>
-              <div className="flex flex-row gap-4 w-full justify-center">
+              <div className="flex flex-row gap-2 w-full justify-center">
                 {[0, 1, 2].map((idx) => {
                   const user = top[idx];
                   let medalText = "";
@@ -106,7 +105,7 @@ export default function TopContributorsByRole({ contributors }) {
                   return (
                     <div
                       key={user ? user.username : idx}
-                      className="flex flex-col items-center justify-center min-w-[100px] relative"
+                      className="flex flex-col items-center justify-center min-w-[120px] max-w-[160px] relative"
                       onMouseEnter={() =>
                         user && setHovered({ username: user.username, roleKey })
                       }
@@ -115,7 +114,7 @@ export default function TopContributorsByRole({ contributors }) {
                       }
                     >
                       <span
-                        className={`inline-block font-semibold text-base mb-1 max-w-[90px] truncate ${
+                        className={`inline-block font-semibold text-base mb-1 max-w-[140px] truncate ${
                           user ? medalText : "text-gray-400"
                         }`}
                         style={{ cursor: user ? "pointer" : "default" }}

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -19,37 +19,110 @@ function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
 }
 
 export default function TopContributorsByRole({ contributors }) {
+  const ROLE_ICONS = {
+    development: (
+      <span className="inline-block mr-2 text-givizBlue4">
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
+          <path
+            d="M8 17l-5-5 5-5M16 7l5 5-5 5"
+            stroke="#2563eb"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    ),
+    testing: (
+      <span className="inline-block mr-2 text-green-500">
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
+          <path
+            d="M9 12l2 2 4-4"
+            stroke="#22c55e"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    ),
+    documentation: (
+      <span className="inline-block mr-2 text-yellow-500">
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24">
+          <path
+            d="M7 7h10M7 11h10M7 15h6"
+            stroke="#eab308"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    ),
+  };
+
   return (
-    <div className="w-full">
-      <h2 className="text-xl font-semibold text-center mb-4">
+    <div className="w-full flex flex-col items-center py-6">
+      <h2 className="text-2xl font-extrabold text-center mb-8 text-givizBlue4 tracking-wide">
         Top 3 Contributors by Role
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="w-full rounded-2xl p-7 flex flex-col gap-8">
         {Object.entries(ROLE_LABELS).map(([roleKey, label]) => {
           const top = getTopContributorsByRole(contributors, roleKey, 3);
           return (
             <div
               key={roleKey}
-              className="bg-white rounded-xl shadow p-4 border border-gray-200"
+              className="flex flex-row items-center gap-6 w-full"
             >
-              <h3 className="text-lg font-bold mb-2 text-givizBlue4 text-center">
-                {label}
-              </h3>
-              {top.length === 0 ? (
-                <div className="text-gray-400 text-center">No contributors</div>
-              ) : (
-                <ol className="list-decimal pl-4">
-                  {top.map((user) => (
-                    <li
-                      key={user.username}
-                      className="mb-1 flex justify-between"
+              <div className="flex items-center min-w-[120px]">
+                {ROLE_ICONS[roleKey]}
+                <span className="text-lg font-bold text-givizBlue4 uppercase tracking-wide drop-shadow">
+                  {label}
+                </span>
+              </div>
+              <div className="flex flex-row gap-4 w-full">
+                {[0, 1, 2].map((idx) => {
+                  const user = top[idx];
+                  let medalBg = "";
+                  let medalText = "";
+                  if (idx === 0) {
+                    medalBg = "bg-gradient-to-br from-yellow-300 to-yellow-500";
+                    medalText = "text-yellow-700";
+                  } else if (idx === 1) {
+                    medalBg = "bg-gradient-to-br from-gray-300 to-gray-400";
+                    medalText = "text-gray-700";
+                  } else if (idx === 2) {
+                    medalBg = "bg-gradient-to-br from-orange-300 to-orange-500";
+                    medalText = "text-orange-700";
+                  }
+                  return (
+                    <div
+                      key={user ? user.username : idx}
+                      className={`flex flex-col items-center justify-center px-4 py-2 rounded-lg min-w-[100px] bg-transparent ${
+                        user ? medalBg : ""
+                      }`}
                     >
-                      <span className="font-medium">{user.username}</span>
-                      <span className="text-gray-500">{user.total} pts</span>
-                    </li>
-                  ))}
-                </ol>
-              )}
+                      <span
+                        className={`inline-block font-semibold text-base mb-1 ${
+                          user ? medalText : "text-gray-400"
+                        }`}
+                      >
+                        {user ? user.username : "-"}
+                      </span>
+                      <span
+                        className={`px-2 py-0.5 ${
+                          user ? medalBg : "bg-gray-200"
+                        } text-xs rounded-full font-bold text-white`}
+                      >
+                        {idx === 0 ? "🥇" : idx === 1 ? "🥈" : "🥉"}
+                      </span>
+                      <span className="text-gray-600 font-mono text-sm mt-1">
+                        {user ? `${user.total} pts` : ""}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           );
         })}

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -66,9 +66,23 @@ export default function TopContributorsByRole({ contributors }) {
       <h2 className="text-2xl font-extrabold text-center mb-8 text-givizBlue4 tracking-wide">
         Top 3 Contributors by Role
       </h2>
-      <div className="w-full rounded-2xl p-7 flex flex-col gap-8">
+      <div className="w-full rounded-2xl p-7 flex flex-col gap-4 bg-white/80">
+        <div className="flex flex-row items-center gap-6 w-full mb-2">
+          <div className="min-w-[120px]" />
+          <div className="flex flex-row gap-4 w-full justify-center">
+            <div className="flex flex-col items-center min-w-[100px]">
+              <span className="text-3xl">🥇</span>
+            </div>
+            <div className="flex flex-col items-center min-w-[100px]">
+              <span className="text-3xl">🥈</span>
+            </div>
+            <div className="flex flex-col items-center min-w-[100px]">
+              <span className="text-3xl">🥉</span>
+            </div>
+          </div>
+        </div>
         {Object.entries(ROLE_LABELS).map(([roleKey, label]) => {
-          const top = getTopContributorsByRole(contributors, roleKey, 3);
+          const top = getTopContributorsByRole(contributors, roleKey, 3) || [];
           return (
             <div
               key={roleKey}
@@ -80,27 +94,21 @@ export default function TopContributorsByRole({ contributors }) {
                   {label}
                 </span>
               </div>
-              <div className="flex flex-row gap-4 w-full">
+              <div className="flex flex-row gap-4 w-full justify-center">
                 {[0, 1, 2].map((idx) => {
                   const user = top[idx];
-                  let medalBg = "";
                   let medalText = "";
                   if (idx === 0) {
-                    medalBg = "bg-gradient-to-br from-yellow-300 to-yellow-500";
                     medalText = "text-yellow-700";
                   } else if (idx === 1) {
-                    medalBg = "bg-gradient-to-br from-gray-300 to-gray-400";
                     medalText = "text-gray-700";
                   } else if (idx === 2) {
-                    medalBg = "bg-gradient-to-br from-orange-300 to-orange-500";
                     medalText = "text-orange-700";
                   }
                   return (
                     <div
                       key={user ? user.username : idx}
-                      className={`flex flex-col items-center justify-center px-4 py-2 rounded-lg min-w-[100px] bg-transparent ${
-                        user ? medalBg : ""
-                      }`}
+                      className={`flex flex-col items-center justify-center min-w-[100px]`}
                     >
                       <span
                         className={`inline-block font-semibold text-base mb-1 ${
@@ -108,13 +116,6 @@ export default function TopContributorsByRole({ contributors }) {
                         }`}
                       >
                         {user ? user.username : "-"}
-                      </span>
-                      <span
-                        className={`px-2 py-0.5 ${
-                          user ? medalBg : "bg-gray-200"
-                        } text-xs rounded-full font-bold text-white`}
-                      >
-                        {idx === 0 ? "🥇" : idx === 1 ? "🥈" : "🥉"}
                       </span>
                       <span className="text-gray-600 font-mono text-sm mt-1">
                         {user ? `${user.total} pts` : ""}

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -35,7 +35,19 @@ function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
 export default function TopContributorsByRole({ contributors }) {
   const [hovered, setHovered] = useState({ username: null, roleKey: null });
   const allRoles = useMemo(() => getAllRoles(contributors), [contributors]);
-  const [selectedRoles, setSelectedRoles] = useState(() => allRoles);
+  const topRoles = useMemo(() => {
+    const counts = {};
+    allRoles.forEach((roleKey) => {
+      counts[roleKey] = Object.values(contributors || {}).filter(
+        (roles) => !!roles[roleKey]
+      ).length;
+    });
+    return allRoles
+      .slice()
+      .sort((a, b) => counts[b] - counts[a])
+      .slice(0, 3);
+  }, [allRoles, contributors]);
+  const [selectedRoles, setSelectedRoles] = useState(() => topRoles);
   const [showChecklist, setShowChecklist] = useState(false);
 
   const handleRoleToggle = (roleKey) => {

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -46,9 +46,6 @@ export default function TopContributorsByRole({ contributors }) {
 
   return (
     <div className="w-full flex flex-col items-center py-6">
-      <h2 className="text-2xl font-extrabold text-center mb-8 text-givizBlue4 tracking-wide">
-        Top 3 Contributors by Role
-      </h2>
       <div className="mb-6 w-full max-w-lg flex flex-wrap gap-3 justify-center">
         {allRoles.map((roleKey) => (
           <label

--- a/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
+++ b/frontend/giviz-frontend/src/components/TopContributorsByRole.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useState } from "react";
 
 const ROLE_LABELS = {
   development: "Developer",
@@ -10,15 +11,16 @@ function getTopContributorsByRole(contributorsData, roleKey, topN = 3) {
   const result = [];
   for (const [username, roles] of Object.entries(contributorsData || {})) {
     if (roles[roleKey]) {
-      const { commits = 0, issues = 0, pulls = 0 } = roles[roleKey];
+      const { commits = 0, issues = 0, pulls = 0, dedication } = roles[roleKey];
       const total = commits + issues + pulls;
-      result.push({ username, total });
+      result.push({ username, total, commits, issues, pulls, dedication });
     }
   }
   return result.sort((a, b) => b.total - a.total).slice(0, topN);
 }
 
 export default function TopContributorsByRole({ contributors }) {
+  const [hovered, setHovered] = useState({ username: null, roleKey: null });
   const ROLE_ICONS = {
     development: (
       <span className="inline-block mr-2 text-givizBlue4">
@@ -66,7 +68,7 @@ export default function TopContributorsByRole({ contributors }) {
       <h2 className="text-2xl font-extrabold text-center mb-8 text-givizBlue4 tracking-wide">
         Top 3 Contributors by Role
       </h2>
-      <div className="w-full rounded-2xl p-7 flex flex-col gap-4 bg-white/80">
+      <div className="w-full rounded-2xl p-7 flex flex-col gap-4">
         <div className="flex flex-row items-center gap-6 w-full mb-2">
           <div className="min-w-[120px]" />
           <div className="flex flex-row gap-4 w-full justify-center">
@@ -108,18 +110,48 @@ export default function TopContributorsByRole({ contributors }) {
                   return (
                     <div
                       key={user ? user.username : idx}
-                      className={`flex flex-col items-center justify-center min-w-[100px]`}
+                      className="flex flex-col items-center justify-center min-w-[100px] relative"
+                      onMouseEnter={() =>
+                        user && setHovered({ username: user.username, roleKey })
+                      }
+                      onMouseLeave={() =>
+                        setHovered({ username: null, roleKey: null })
+                      }
                     >
                       <span
-                        className={`inline-block font-semibold text-base mb-1 ${
+                        className={`inline-block font-semibold text-base mb-1 max-w-[90px] truncate ${
                           user ? medalText : "text-gray-400"
                         }`}
+                        style={{ cursor: user ? "pointer" : "default" }}
+                        title={user ? user.username : "-"}
                       >
                         {user ? user.username : "-"}
                       </span>
                       <span className="text-gray-600 font-mono text-sm mt-1">
                         {user ? `${user.total} pts` : ""}
                       </span>
+                      {user &&
+                        hovered.username === user.username &&
+                        hovered.roleKey === roleKey && (
+                          <div className="absolute left-1/2 -translate-x-1/2 top-10 z-10 bg-white/90 text-gray-800 rounded-lg shadow-lg border border-gray-200 px-3 py-2 text-xs whitespace-pre">
+                            <div>
+                              <span className="font-bold">Username:</span>{" "}
+                              {user.username}
+                            </div>
+                            <div>
+                              <span className="font-bold">Commits points:</span>{" "}
+                              {user.commits}
+                            </div>
+                            <div>
+                              <span className="font-bold">Issues points:</span>{" "}
+                              {user.issues}
+                            </div>
+                            <div>
+                              <span className="font-bold">Pulls points:</span>{" "}
+                              {user.pulls}
+                            </div>
+                          </div>
+                        )}
                     </div>
                   );
                 })}

--- a/frontend/giviz-frontend/src/pages/Analysis.jsx
+++ b/frontend/giviz-frontend/src/pages/Analysis.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import TopContributorsByRole from "../components/TopContributorsByRole";
 import { useNavigate } from "react-router-dom";
 import { useRepo } from "../hooks/useRepo";
 import EffortPieChart from "../components/EffortPieChart";
@@ -12,6 +13,8 @@ export default function Analysis() {
   const globalEffortPercentages = repoInfo?.analysis?.globalEffortPercentages;
   const [contributors, setContributors] = useState([]);
   const [loadingContrib, setLoadingContrib] = useState(false);
+  const [roleContributors, setRoleContributors] = useState(null);
+  const [loadingRoleContrib, setLoadingRoleContrib] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -33,7 +36,32 @@ export default function Analysis() {
         setLoadingContrib(false);
       }
     }
+    async function fetchRoleContributors() {
+      if (!repoInfo?.owner || !repoInfo?.repo) return;
+      setLoadingRoleContrib(true);
+      try {
+        const API_BASE =
+          import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api";
+        const url = `${API_BASE}/merge/contributors_effort_by_category/`;
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ owner: repoInfo.owner, repo: repoInfo.repo }),
+        });
+        const data = await res.json();
+        if (data && data.contributors) {
+          setRoleContributors(data.contributors);
+        } else {
+          setRoleContributors(null);
+        }
+      } catch {
+        setRoleContributors(null);
+      } finally {
+        setLoadingRoleContrib(false);
+      }
+    }
     fetchContributors();
+    fetchRoleContributors();
   }, [repoInfo]);
 
   function handleSelectContributor(username) {
@@ -120,6 +148,17 @@ export default function Analysis() {
           owner={repoInfo?.owner}
           repo={repoInfo?.repo}
         />
+      </Card>
+      <Card className="mt-8 w-full max-w-2xl flex flex-col items-center">
+        {loadingRoleContrib ? (
+          <div className="text-center">Loading top contributors by role...</div>
+        ) : roleContributors ? (
+          <TopContributorsByRole contributors={roleContributors} />
+        ) : (
+          <div className="text-center text-gray-400">
+            No contributor data available for top roles.
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/frontend/giviz-frontend/src/pages/Analysis.jsx
+++ b/frontend/giviz-frontend/src/pages/Analysis.jsx
@@ -150,9 +150,14 @@ export default function Analysis() {
         />
       </Card>
       <Card className="mt-8 w-full max-w-2xl flex flex-col items-center">
-        <h2 className="text-xl font-semibold text-center mr-2">
-          Top 3 Contributors by Role
-        </h2>
+        <div className="flex items-center mb-4">
+          <h2 className="text-xl font-semibold text-center mr-2">
+            Top 3 Contributors by Role
+          </h2>
+          <InfoTooltip
+            text={`This chart shows the top 3 contributors for each role detected in the repository. Roles are assigned by AI based on the amount of lines added and deleted, issues opened, and pull requests merged.`}
+          />
+        </div>
         {loadingRoleContrib ? (
           <div className="text-center">Loading top contributors by role...</div>
         ) : roleContributors ? (

--- a/frontend/giviz-frontend/src/pages/Analysis.jsx
+++ b/frontend/giviz-frontend/src/pages/Analysis.jsx
@@ -150,6 +150,9 @@ export default function Analysis() {
         />
       </Card>
       <Card className="mt-8 w-full max-w-2xl flex flex-col items-center">
+        <h2 className="text-xl font-semibold text-center mr-2">
+          Top 3 Contributors by Role
+        </h2>
         {loadingRoleContrib ? (
           <div className="text-center">Loading top contributors by role...</div>
         ) : roleContributors ? (


### PR DESCRIPTION
This pull request introduces a new feature to display the top contributors by role in the `Analysis` page of the frontend. It includes a new component, `TopContributorsByRole`, and integrates it with the existing `Analysis` page to fetch and render contributor data grouped by roles. Below are the key changes:

### New Component: `TopContributorsByRole`

* A new component, `TopContributorsByRole`, is added to display the top three contributors for each role. It includes functionality for filtering roles, sorting contributors by their contributions, and showing detailed stats on hover. (`[frontend/giviz-frontend/src/components/TopContributorsByRole.jsxR1-R183](diffhunk://#diff-bc1acedc5fe2d6583241a55657d88dc3dcbe7ab55c9a4e2146e18f7e6d48af65R1-R183)`)

### Integration with the `Analysis` Page

* The `Analysis` page now imports and uses the `TopContributorsByRole` component. (`[[1]](diffhunk://#diff-dc710868c59ef5bf0ee9a352bc5167536b8d502a38add1b0e3b39939cd1dc15dR2)`, `[[2]](diffhunk://#diff-dc710868c59ef5bf0ee9a352bc5167536b8d502a38add1b0e3b39939cd1dc15dR152-R170)`)
* Added state management for `roleContributors` and `loadingRoleContrib` to handle role-based contributor data. (`[frontend/giviz-frontend/src/pages/Analysis.jsxR16-R17](diffhunk://#diff-dc710868c59ef5bf0ee9a352bc5167536b8d502a38add1b0e3b39939cd1dc15dR16-R17)`)
* Introduced a new `fetchRoleContributors` function to fetch contributor data grouped by roles from the backend API. This function is called alongside the existing `fetchContributors`. (`[frontend/giviz-frontend/src/pages/Analysis.jsxR39-R64](diffhunk://#diff-dc710868c59ef5bf0ee9a352bc5167536b8d502a38add1b0e3b39939cd1dc15dR39-R64)`)